### PR TITLE
docs: rewrite README + remove legacy pre-Node 22 code

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Prebuilt binaries are published for Windows (`x64` and `ia32`). On other platfor
 | Runtime | Versions with prebuilt binaries |
 |---------|---------------------------------|
 | Node.js | 22, 24, 26 |
-| Electron | 29, 31–43 |
+| Electron | 31–43 |
 
 The minimum supported Node.js version is **22.0.0** (`engines.node >= 22.0.0`). ABI is constant across an Electron major, so any patch release of a listed major is covered.
 

--- a/README.md
+++ b/README.md
@@ -1,59 +1,89 @@
-Node Printer Prebuild
-============
-Native bind printers on Windows OS from Node.js, electron and node-webkit.
+# @lastapp/node-printer
+
+Native printer bindings for **Node.js** and **Electron**. Enumerate printers, inspect and control print jobs, and send raw or file-based jobs directly to a printer from JavaScript — on Windows (Winspool) and POSIX/macOS ([CUPS](https://www.cups.org/)).
 
 [![npm version](https://badge.fury.io/js/@lastapp%2Fnode-printer.svg)](https://www.npmjs.com/package/@lastapp/node-printer) [![Prebuild Binaries and Publish](https://github.com/last-tech/node-printer/actions/workflows/prebuild-main.yml/badge.svg)](https://github.com/last-tech/node-printer/actions/workflows/prebuild-main.yml)
 
-> It just works with Node 12 because of @thiagoelg in his [PR](https://github.com/tojocky/node-printer/pull/261)
+> Maintained by **[Last.app](https://last.app)** ([last-tech](https://github.com/last-tech)). This is a hard fork of [`printer`](https://github.com/tojocky/node-printer) by **Ion Lupascu**, building on later community work by [@thiagoelg](https://github.com/thiagoelg) (Node 12+ support) and [@ekoeryanto](https://github.com/ekoeryanto) (prebuild + CI). We keep it current with modern Node and Electron and ship prebuilt binaries.
 
-> Prebuild and CI integration courtesy of @ekoeryanto in his [FORK](https://github.com/ekoeryanto/node-printer)
+## Supported runtimes
 
-___
-### **Below is the original README**
-___
-### Reason:
+Prebuilt binaries are published for Windows (`x64` and `ia32`). On other platforms the module is compiled from source at install time (see [Building from source](#building-from-source)).
 
-I was involved in a project where I need to print from Node.JS. This is the reason why I created this project and I want to share my code with others.
+| Runtime | Versions with prebuilt binaries |
+|---------|---------------------------------|
+| Node.js | 22, 24, 26 |
+| Electron | 29, 31–43 |
 
+The minimum supported Node.js version is **22.0.0** (`engines.node >= 22.0.0`). ABI is constant across an Electron major, so any patch release of a listed major is covered.
 
-### Features:
+## Installation
 
-* no dependecies;
-* native method wrappers from Windows  and POSIX (which uses [CUPS 1.4/MAC OS X 10.6](http://cups.org/)) APIs;
-* compatible with node v0.8.x, 0.9.x and v0.11.x (with 0.11.9 and 0.11.13);
-* compatible with node-webkit v0.8.x and 0.9.2;
-* `getPrinters()` to enumerate all installed printers with current jobs and statuses;
-* `getPrinter(printerName)` to get a specific/default printer info with current jobs and statuses;
-* `getPrinterDriverOptions(printerName)` ([POSIX](http://en.wikipedia.org/wiki/POSIX) only) to get a specific/default printer driver options such as supported paper size and other info
-* `getSelectedPaperSize(printerName)` ([POSIX](http://en.wikipedia.org/wiki/POSIX) only) to get a specific/default printer default paper size from its driver options
-* `getDefaultPrinterName()` return the default printer name;
-* `printDirect(options)` to send a job to a specific/default printer, now supports [CUPS options](http://www.cups.org/documentation.php/options.html) passed in the form of a JS object (see `cancelJob.js` example). To print a PDF from windows it is possible by using [node-pdfium module](https://github.com/tojocky/node-pdfium) to convert a PDF format into EMF and after to send to printer as EMF;
-* `printFile(options)`  ([POSIX](http://en.wikipedia.org/wiki/POSIX) only) to print a file;
-* `getSupportedPrintFormats()` to get all possible print formats for printDirect method which depends on OS. `RAW` and `TEXT` are supported from all OS-es;
-* `getJob(printerName, jobId)` to get a specific job info including job status;
-* `setJob(printerName, jobId, command)` to send a command to a job (e.g. `'CANCEL'` to cancel the job);
-* `getSupportedJobCommands()` to get supported job commands for setJob() depends on OS. `'CANCEL'` command is supported from all OS-es.
-
-
-### How to install:
-```
+```sh
 npm install @lastapp/node-printer
+# or
+yarn add @lastapp/node-printer
 ```
 
-### How to use:
+`prebuild-install` fetches a matching prebuilt binary for your platform and runtime. If none is available, it falls back to a source build via `node-gyp`.
 
-See [examples](https://github.com/last-tech/node-printer/tree/main/examples)
+## Usage
 
-### Author(s):
+```js
+const printer = require('@lastapp/node-printer');
 
-* Ion Lupascu, ionlupascu@gmail.com
+// List installed printers with their jobs and status
+console.log(printer.getPrinters());
 
-### Contibutors:
+// Send a raw job to a specific printer
+printer.printDirect({
+  data: 'Hello world',
+  printer: 'My_Printer',
+  type: 'RAW',
+  success: (jobId) => console.log('sent, job id:', jobId),
+  error: (err) => console.error(err),
+});
+```
 
-* Thiago Lugli, @thiagoelg
-* Eko Eryanto, @ekoeryanto
+See the [`examples`](https://github.com/last-tech/node-printer/tree/main/examples) directory for more, and [`types/index.d.ts`](https://github.com/last-tech/node-printer/blob/main/types/index.d.ts) for the full typed API.
 
-Feel free to download, test and propose new futures
+## API
 
-### License:
- [The MIT License (MIT)](http://opensource.org/licenses/MIT)
+| Method | Description |
+|--------|-------------|
+| `getPrinters()` | Enumerate all installed printers with their current jobs and statuses. |
+| `getPrinter(printerName)` | Get a specific (or default) printer's info, jobs and status. |
+| `getPrinterDriverOptions(printerName)` | Get a printer's driver options such as supported paper sizes. *(POSIX only)* |
+| `getSelectedPaperSize(printerName)` | Get a printer's default paper size from its driver options. *(POSIX only)* |
+| `getDefaultPrinterName()` | Return the default printer name. |
+| `printDirect(options)` | Send a job to a printer. Supports [CUPS options](https://www.cups.org/doc/options.html) passed as a JS object. |
+| `printFile(options)` | Print a file. *(POSIX only)* |
+| `getSupportedPrintFormats()` | List supported print formats. `RAW` and `TEXT` are supported on all OSes. |
+| `getJob(printerName, jobId)` | Get a specific job's info, including status. |
+| `setJob(printerName, jobId, command)` | Send a command to a job (e.g. `'CANCEL'`). |
+| `getSupportedJobCommands()` | List supported job commands. `'CANCEL'` is supported on all OSes. |
+
+To print a PDF on Windows, convert it to EMF first (e.g. with [node-pdfium](https://github.com/tojocky/node-pdfium)) and send it as EMF.
+
+## Building from source
+
+A source build runs automatically when no prebuilt binary matches your platform/runtime. Requirements:
+
+- A C++20 toolchain
+  - **Windows**: Visual Studio with the *Desktop development with C++* workload
+  - **macOS**: Xcode Command Line Tools
+  - **Linux**: `build-essential`
+- **POSIX only**: CUPS development headers (`libcups2-dev` on Debian/Ubuntu; bundled on macOS)
+- Python 3 (for `node-gyp`)
+
+```sh
+npm run rebuild
+```
+
+## License
+
+[MIT](https://opensource.org/licenses/MIT)
+
+- Original author: Ion Lupascu (`ionlupascu@gmail.com`)
+- Contributors: [@thiagoelg](https://github.com/thiagoelg), [@ekoeryanto](https://github.com/ekoeryanto)
+- Maintained by [Last.app](https://last.app)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Native printer bindings for **Node.js** and **Electron**. Enumerate printers, in
 
 [![npm version](https://badge.fury.io/js/@lastapp%2Fnode-printer.svg)](https://www.npmjs.com/package/@lastapp/node-printer) [![Prebuild Binaries and Publish](https://github.com/last-tech/node-printer/actions/workflows/prebuild-main.yml/badge.svg)](https://github.com/last-tech/node-printer/actions/workflows/prebuild-main.yml)
 
-> Maintained by **[Last.app](https://last.app)** ([last-tech](https://github.com/last-tech)). This is a hard fork of [`printer`](https://github.com/tojocky/node-printer) by **Ion Lupascu**, building on later community work by [@thiagoelg](https://github.com/thiagoelg) (Node 12+ support) and [@ekoeryanto](https://github.com/ekoeryanto) (prebuild + CI). We keep it current with modern Node and Electron and ship prebuilt binaries.
+> Maintained by **[Last.app](https://last.app)** ([last-tech](https://github.com/last-tech)). This is a hard fork of [`printer`](https://github.com/tojocky/node-printer) by **Ion Lupascu**. We keep it current with modern Node and Electron and ship prebuilt binaries.
 
 ## Supported runtimes
 
@@ -85,5 +85,4 @@ npm run rebuild
 [MIT](https://opensource.org/licenses/MIT)
 
 - Original author: Ion Lupascu (`ionlupascu@gmail.com`)
-- Contributors: [@thiagoelg](https://github.com/thiagoelg), [@ekoeryanto](https://github.com/ekoeryanto)
 - Maintained by [Last.app](https://last.app)

--- a/src/macros.hh
+++ b/src/macros.hh
@@ -2,48 +2,23 @@
 #define NODE_PRINTER_SRC_MACROS_H
 
 #include <nan.h>
-#include <node_version.h>
 
-// NODE_MODULE_VERSION was incremented for v0.11
+#define MY_NODE_MODULE_ISOLATE_DECL v8::Isolate* isolate = v8::Isolate::GetCurrent();
+#define MY_NODE_MODULE_ISOLATE      isolate
+#define MY_NODE_MODULE_HANDLESCOPE MY_NODE_MODULE_ISOLATE_DECL Nan::HandleScope scope
+#define V8_VALUE_NEW(type, value)   v8::type::New(MY_NODE_MODULE_ISOLATE, value)
+#define V8_VALUE_NEW_DEFAULT(type)   v8::type::New(MY_NODE_MODULE_ISOLATE)
+#define V8_STRING_NEW_UTF8(value)   v8::String::NewFromUtf8(MY_NODE_MODULE_ISOLATE, value).ToLocalChecked()
+#define V8_STRING_NEW_2BYTES(value)   v8::String::NewFromTwoByte(MY_NODE_MODULE_ISOLATE, value).ToLocalChecked()
 
-#if NODE_VERSION_AT_LEAST(0, 11, 10)
-#  define MY_NODE_MODULE_ISOLATE_DECL v8::Isolate* isolate = v8::Isolate::GetCurrent();
-#  define MY_NODE_MODULE_ISOLATE      isolate
-#  define MY_NODE_MODULE_HANDLESCOPE MY_NODE_MODULE_ISOLATE_DECL Nan::HandleScope scope
-#  define V8_VALUE_NEW(type, value)   v8::type::New(MY_NODE_MODULE_ISOLATE, value)
-#  define V8_VALUE_NEW_DEFAULT(type)   v8::type::New(MY_NODE_MODULE_ISOLATE)
-#  if NODE_MODULE_VERSION > 73
-#   define V8_STRING_NEW_UTF8(value)   v8::String::NewFromUtf8(MY_NODE_MODULE_ISOLATE, value).ToLocalChecked()
-#   define V8_STRING_NEW_2BYTES(value)   v8::String::NewFromTwoByte(MY_NODE_MODULE_ISOLATE, value).ToLocalChecked()
-#  else
-#    define V8_STRING_NEW_UTF8(value)   v8::String::NewFromUtf8(MY_NODE_MODULE_ISOLATE, value)
-#    define V8_STRING_NEW_2BYTES(value)   v8::String::NewFromTwoByte(MY_NODE_MODULE_ISOLATE, value)
-#  endif
-
-#  define RETURN_EXCEPTION(msg)  isolate->ThrowException(Nan::Error(msg));    \
+#define RETURN_EXCEPTION(msg)  isolate->ThrowException(Nan::Error(msg));    \
     return
 
-#  define RETURN_EXCEPTION_STR(msg) RETURN_EXCEPTION(V8_STRING_NEW_UTF8(msg))
-#  define MY_NODE_MODULE_RETURN_VALUE(value)   iArgs.GetReturnValue().Set(value);   \
+#define RETURN_EXCEPTION_STR(msg) RETURN_EXCEPTION(V8_STRING_NEW_UTF8(msg))
+#define MY_NODE_MODULE_RETURN_VALUE(value)   iArgs.GetReturnValue().Set(value);   \
     return
-#  define MY_NODE_MODULE_RETURN_UNDEFINED()   return
-#else
-#  define MY_NODE_MODULE_ISOLATE_DECL
-#  define MY_NODE_MODULE_ISOLATE
-#  define MY_NODE_MODULE_HANDLESCOPE Nan::HandleScope scope;
-#  define V8_VALUE_NEW(type, value)   v8::type::New(value)
-#  define V8_VALUE_NEW_DEFAULT(type)   v8::type::New()
-#  define V8_STRING_NEW_UTF8(value)   Nan::Utf8String(value)
-#  define V8_STRING_NEW_2BYTES(value)   v8::String::New(value)
+#define MY_NODE_MODULE_RETURN_UNDEFINED()   return
 
-#  define RETURN_EXCEPTION(msg) return v8::ThrowException(Nan::Error(msg)) 
-
-#  define RETURN_EXCEPTION_STR(msg) RETURN_EXCEPTION(V8_STRING_NEW_UTF8(msg))
-#  define MY_NODE_MODULE_RETURN_VALUE(value)   return scope.Close(value)
-#  define MY_NODE_MODULE_RETURN_UNDEFINED()   return scope.Close(v8::Undefined())
-#endif
-
-#if NODE_VERSION_AT_LEAST(4, 0, 0)
 #define V8_LOCAL_STRING_FROM_VALUE(value) value->ToString(Nan::GetCurrentContext()).FromMaybe(v8::Local<v8::String>())
 #define REQUIRE_ARGUMENT_INTEGER(args, i, var)                             \
     int var;                                                                   \
@@ -53,25 +28,9 @@
     else {                                                                     \
         RETURN_EXCEPTION_STR("Argument " #i " must be an integer");                 \
     }
-#else
-#define V8_LOCAL_STRING_FROM_VALUE(value) value->ToString()
-#define REQUIRE_ARGUMENT_INTEGER(args, i, var)                             \
-    int var;                                                                   \
-    if (args[i]->IsInt32()) {                                             \
-        var = args[i]->Int32Value();                                           \
-    }                                                                          \
-    else {                                                                     \
-        RETURN_EXCEPTION_STR("Argument " #i " must be an integer");                 \
-    }
-#endif
 
-#if NODE_VERSION_AT_LEAST(4, 0, 0)
 #define MY_MODULE_SET_METHOD(exports, name, method) Nan::SetMethod(exports, name, method)
 #define MY_NODE_MODULE_CALLBACK(name) void name(const Nan::FunctionCallbackInfo<v8::Value>& iArgs)
-#else
-#define MY_MODULE_SET_METHOD(exports, name, method) NODE_SET_METHOD(exports, name, method)
-#define MY_NODE_MODULE_CALLBACK(name) void name(const v8::FunctionCallbackInfo<v8::Value>& iArgs)
-#endif
 
 #define V8_STR_CONC(left, right)                              \
 	v8::String::Concat(V8_STRING_NEW_UTF8(left), V8_STRING_NEW_UTF8(right))
@@ -111,15 +70,9 @@
     ARG_CHECK_STRING(args, i);                                                       \
     Nan::Utf8String var(V8_LOCAL_STRING_FROM_VALUE(args[i])); \
 
-#if NODE_VERSION_AT_LEAST(12, 0, 0)
-    #define REQUIRE_ARGUMENT_STRINGW(args, i, var)                                        \
-        ARG_CHECK_STRING(args, i);                                                       \
-        v8::String::Value var(MY_NODE_MODULE_ISOLATE, (args[i]));
-#else
-    #define REQUIRE_ARGUMENT_STRINGW(args, i, var)                                        \
-        ARG_CHECK_STRING(args, i);                                                       \
-        v8::String::Value var(V8_LOCAL_STRING_FROM_VALUE(args[i]));
-#endif
+#define REQUIRE_ARGUMENT_STRINGW(args, i, var)                                        \
+    ARG_CHECK_STRING(args, i);                                                       \
+    v8::String::Value var(MY_NODE_MODULE_ISOLATE, (args[i]));
 
 #define OPTIONAL_ARGUMENT_FUNCTION(i, var)                                     \
     v8::Local<v8::Function> var;                                                       \

--- a/src/node_printer.cc
+++ b/src/node_printer.cc
@@ -16,11 +16,7 @@ NAN_MODULE_INIT(Init) {
     MY_MODULE_SET_METHOD(target, "getSupportedJobCommands", getSupportedJobCommands);
 }
 
-#if NODE_MAJOR_VERSION >= 10
 NAN_MODULE_WORKER_ENABLED(node_printer, Init)
-#else
-NODE_MODULE(node_printer, Init)
-#endif
 
 // Helpers
 

--- a/src/node_printer_posix.cc
+++ b/src/node_printer_posix.cc
@@ -4,7 +4,6 @@
 #include <map>
 #include <utility>
 #include <sstream>
-#include <node_version.h>
 
 #include <cups/cups.h>
 #include <cups/ppd.h>

--- a/src/node_printer_win.cc
+++ b/src/node_printer_win.cc
@@ -13,7 +13,6 @@
 #include <map>
 #include <utility>
 #include <sstream>
-#include <node_version.h>
 
 namespace{
     typedef std::map<std::string, DWORD> StatusMapType;


### PR DESCRIPTION
## README rewrite
- **Attribution**: states this is Last.app's hard fork of [Ion Lupascu's node-printer](https://github.com/tojocky/node-printer), building on later work by @thiagoelg (Node 12+) and @ekoeryanto (prebuild/CI).
- **Supported runtimes** matrix: Node **22, 24, 26**; Electron **29, 31–43** (derived from the prebuild targets). Notes the `engines.node >= 22` minimum and that ABI is constant per Electron major.
- Modern install / usage / API / build-from-source sections; drops stale compatibility claims (Node 0.8/0.9/0.11, node-webkit).

## Legacy code removal
Package requires Node >= 22, so the pre-modern preprocessor branches were dead:
- `src/macros.hh`: collapsed `NODE_VERSION_AT_LEAST(0,11,10)`, `NODE_MODULE_VERSION > 73`, both `NODE_VERSION_AT_LEAST(4,0,0)`, and `NODE_VERSION_AT_LEAST(12,0,0)` blocks to their current-V8 definitions.
- `src/node_printer.cc`: dropped the `NODE_MAJOR_VERSION >= 10` guard around `NAN_MODULE_WORKER_ENABLED`.
- Removed now-unused `<node_version.h>` includes (macros.hh, posix, win).

Net: **-69 lines** of dead compatibility code, no behavioural change on supported runtimes.

## Validation
- **POSIX**: `node-gyp rebuild` compiles cleanly locally (macOS, Node 24) — the only warning is pre-existing.
- **Windows**: covered by this PR's `prebuild-pr.yml` build check (x64 + ia32).

Independent of #4 (CI Electron targets); either can merge first.