### PR TITLE
ci: drop Electron 29 prebuild target

### DIFF
--- a/.github/workflows/prebuild-main.yml
+++ b/.github/workflows/prebuild-main.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Prebuild Electron
         run: >-
           npm run prebuild -- --strip --arch x64 -r electron
-          -t 29.0.0
           -t 31.0.0
           -t 32.0.0
           -t 33.0.0
@@ -60,7 +59,6 @@ jobs:
       - name: Prebuild Electron
         run: >-
           npm run prebuild -- --strip --arch ia32 -r electron
-          -t 29.0.0
           -t 31.0.0
           -t 32.0.0
           -t 33.0.0

--- a/.github/workflows/prebuild-pr.yml
+++ b/.github/workflows/prebuild-pr.yml
@@ -23,7 +23,6 @@ jobs:
       - name: Prebuild Electron
         run: >-
           npm run prebuild -- --strip --arch x64 -r electron
-          -t 29.0.0
           -t 31.0.0
           -t 32.0.0
           -t 33.0.0
@@ -55,7 +54,6 @@ jobs:
       - name: Prebuild Electron
         run: >-
           npm run prebuild -- --strip --arch ia32 -r electron
-          -t 29.0.0
           -t 31.0.0
           -t 32.0.0
           -t 33.0.0


### PR DESCRIPTION
Electron 29 is unused — the only consumer (`pos/electron`) is on Electron 41 (moving to 42). It was just the inherited floor of the upstream target list.

Lowers the prebuild floor to **Electron 31**; the rest of the target set (31–43) is unchanged.

## Follow-up for consistency
The "Electron 29, 31–43" wording in the README (#5) and RELEASING.md (#6) should become "31–43" — updating those in their PRs.